### PR TITLE
Support denios prod

### DIFF
--- a/via-environment.js
+++ b/via-environment.js
@@ -19,6 +19,8 @@ module.exports = {
             return 'stage';
         } else if (os.hostname().match(/mrboston-prod/i)) {
             return 'prod';
+        } else if (os.hostname().match(/denios-us(\.magemojo)*\.com/i)) {
+            return 'prod';
         } else {
             return 'dev';
         }


### PR DESCRIPTION
Hostname should always be `denios-us.magemojo.com` but this also catches `denios-us.com`.