### PR TITLE
Changes to how we handle Denios deploys.

### DIFF
--- a/via-environment.js
+++ b/via-environment.js
@@ -19,8 +19,16 @@ module.exports = {
             return 'stage';
         } else if (os.hostname().match(/mrboston-prod/i)) {
             return 'prod';
-        } else if (os.hostname().match(/denios-us(\.magemojo)*\.com/i)) {
-            return 'prod';
+        } else if (os.hostname() == 'jenkins') {
+            cwd = process.cwd();
+
+            //The only way to tell if we're deploying to Denios staging vs. prod is by looking at the filesystem path.
+            //This will be the name of the jenkins job workspace
+            if (cwd.match(/denios.*?production.*?deploy/i)) {
+                return 'prod';
+            } else if (cwd.match(/denios.*?staging.*?deploy/i)) {
+                return 'stage';
+            }
         } else {
             return 'dev';
         }


### PR DESCRIPTION
We can't actually use hostname since both staging & production deploys happen on the jenkins server.

Instead, we look at the filesystem path (which will match the name of the Jenkins job).

I tested this by cloning Denios to the appropriate Jenkins "workspace" directory, manually adding the changes to `node_modules/via-environment/via-environment.js` and running `grunt`.

It correctly detected that it was a **prod** deploy.